### PR TITLE
Improve Encode performance

### DIFF
--- a/base32.go
+++ b/base32.go
@@ -32,12 +32,12 @@ func (e *encoding) Decode(s string) uint64 {
 
 // Encode bits of 64-bit word into a string.
 func (e *encoding) Encode(x uint64) string {
-	s := ""
-	for x != 0 {
-		s = string(e.encode[x&0x1f]) + s
+	b := [12]byte{}
+	for i := 0; i < 12; i++ {
+		b[11-i] = e.encode[x&0x1f]
 		x >>= 5
 	}
-	return s
+	return string(b[:])
 }
 
 // Base32Encoding with the Geohash alphabet.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,9 @@
+package geohash
+
+import "testing"
+
+func BenchmarkEncode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Encode(RandomPoint())
+	}
+}

--- a/geohash.go
+++ b/geohash.go
@@ -2,10 +2,7 @@
 // geohashes.
 package geohash
 
-import (
-	"fmt"
-	"math"
-)
+import "math"
 
 // Encode the point (lat, lng) as a string geohash with the standard 12
 // characters of precision.
@@ -19,7 +16,7 @@ func EncodeWithPrecision(lat, lng float64, chars uint) string {
 	bits := 5 * chars
 	inthash := EncodeIntWithPrecision(lat, lng, bits)
 	enc := base32encoding.Encode(inthash)
-	return fmt.Sprintf("%0*s", int(chars), enc)
+	return enc[12-chars:]
 }
 
 // EncodeInt encodes the point (lat, lng) to a 64-bit integer geohash.

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -1,8 +1,6 @@
 package geohash
 
 import (
-	"math"
-	"math/rand"
 	"testing"
 	"testing/quick"
 )
@@ -47,19 +45,6 @@ func TestBase32Encode(t *testing.T) {
 	s := base32encoding.Encode(0xdfe082)
 	if "ezs42" != s {
 		t.Errorf("incorrect base64 encoding")
-	}
-}
-
-func RandomBox() Box {
-	lat1 := -90 + 180*rand.Float64()
-	lat2 := -90 + 180*rand.Float64()
-	lng1 := -180 + 360*rand.Float64()
-	lng2 := -180 + 360*rand.Float64()
-	return Box{
-		MinLat: math.Min(lat1, lat2),
-		MaxLat: math.Max(lat1, lat2),
-		MinLng: math.Min(lng1, lng2),
-		MaxLng: math.Max(lng1, lng2),
 	}
 }
 

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -43,7 +43,7 @@ func TestBase32Decode(t *testing.T) {
 
 func TestBase32Encode(t *testing.T) {
 	s := base32encoding.Encode(0xdfe082)
-	if "ezs42" != s {
+	if "0000000ezs42" != s {
 		t.Errorf("incorrect base64 encoding")
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,23 @@
+package geohash
+
+import (
+	"math"
+	"math/rand"
+)
+
+func RandomPoint() (lat, lng float64) {
+	lat = -90 + 180*rand.Float64()
+	lng = -180 + 360*rand.Float64()
+	return
+}
+
+func RandomBox() Box {
+	lat1, lng1 := RandomPoint()
+	lat2, lng2 := RandomPoint()
+	return Box{
+		MinLat: math.Min(lat1, lat2),
+		MaxLat: math.Max(lat1, lat2),
+		MinLng: math.Min(lng1, lng2),
+		MaxLng: math.Max(lng1, lng2),
+	}
+}


### PR DESCRIPTION
I noticed that `Encode` was performing significantly worse than other libraries. See benchmarks in the pierrre/geohash package.

https://github.com/pierrre/geohash/blob/ec5e54f782171f4ba9f3bb1696410f9e7297b8c1/geohash_benchmark_test.go

This PR adds a benchmark for `Encode` and resolves the underlying problem, which was unnecessary use of `fmt.Sprintf` to pad with zeros.
