### PR TITLE
Improve EncodeInt performance

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -2,8 +2,27 @@ package geohash
 
 import "testing"
 
+func randomPoints(n int) [][2]float64 {
+	var points [][2]float64
+	for i := 0; i < n; i++ {
+		lat, lon := RandomPoint()
+		points = append(points, [2]float64{lat, lon})
+	}
+	return points
+}
+
 func BenchmarkEncode(b *testing.B) {
+	points := randomPoints(b.N)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Encode(RandomPoint())
+		Encode(points[i][0], points[i][1])
+	}
+}
+
+func BenchmarkEncodeInt(b *testing.B) {
+	points := randomPoints(b.N)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		EncodeInt(points[i][0], points[i][1])
 	}
 }

--- a/geohash.go
+++ b/geohash.go
@@ -192,15 +192,18 @@ func NeighborsIntWithPrecision(hash uint64, bits uint) []uint64 {
 	}
 }
 
+// precalculated for performance
+var exp232 = math.Exp2(32)
+
 // Encode the position of x within the range -r to +r as a 32-bit integer.
 func encodeRange(x, r float64) uint32 {
 	p := (x + r) / (2 * r)
-	return uint32(p * math.Exp2(32))
+	return uint32(p * exp232)
 }
 
 // Decode the 32-bit range encoding X back to a value in the range -r to +r.
 func decodeRange(X uint32, r float64) float64 {
-	p := float64(X) / math.Exp2(32)
+	p := float64(X) / exp232
 	x := 2*r*p - r
 	return x
 }


### PR DESCRIPTION
~5x speed boost to EncodeInt by precalculating math.Exp2(32)
as a global variable.

before:
BenchmarkEncodeInt-8	20000000            79.8 ns/op

after:
BenchmarkEncodeInt-8	100000000           13.9 ns/op

*On a MacBook Pro 15" 2.8 GHz Intel Core i7 using Go 1.8.*