### PR TITLE
doc: fix README ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Go [geohash](https://en.wikipedia.org/wiki/Geohash) library offering encoding
 and decoding for string and integer geohashes.
 
 [![go.dev Reference](https://img.shields.io/badge/doc-reference-007d9b?logo=go&style=flat-square)](https://pkg.go.dev/github.com/mmcloughlin/geohash)
-![Build status](https://img.shields.io/github/workflow/status/mmcloughlin/geohash/ci/master.svg?style=flat-square)
+![Build status](https://img.shields.io/github/actions/workflow/status/mmcloughlin/geohash/ci.yml?style=flat-square)
 [![Coverage](https://img.shields.io/codecov/c/github/mmcloughlin/geohash?style=flat-square)](https://codecov.io/github/mmcloughlin/geohash)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mmcloughlin/geohash?style=flat-square)](https://goreportcard.com/report/github.com/mmcloughlin/geohash)
 

--- a/README.tmpl
+++ b/README.tmpl
@@ -4,7 +4,7 @@ Go [geohash](https://en.wikipedia.org/wiki/Geohash) library offering encoding
 and decoding for string and integer geohashes.
 
 [![go.dev Reference](https://img.shields.io/badge/doc-reference-007d9b?logo=go&style=flat-square)](https://pkg.go.dev/github.com/mmcloughlin/geohash)
-![Build status](https://img.shields.io/github/workflow/status/mmcloughlin/geohash/ci/master.svg?style=flat-square)
+![Build status](https://img.shields.io/github/actions/workflow/status/mmcloughlin/geohash/ci.yml?style=flat-square)
 [![Coverage](https://img.shields.io/codecov/c/github/mmcloughlin/geohash?style=flat-square)](https://codecov.io/github/mmcloughlin/geohash)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mmcloughlin/geohash?style=flat-square)](https://goreportcard.com/report/github.com/mmcloughlin/geohash)
 


### PR DESCRIPTION
Update URL for CI status badge in README.

See https://github.com/badges/shields/issues/8671
